### PR TITLE
fix: dereference nested refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@docusaurus/core": "2.4.0",
     "@docusaurus/preset-classic": "2.4.0",
     "@mdx-js/react": "^1.6.22",
-    "@stoplight/json-ref-readers": "^1.2.2",
+    "@stoplight/json-schema-ref-parser": "^9.2.5",
     "clsx": "^1.2.1",
     "deepmerge": "^4.3.1",
     "docusaurus-json-schema-plugin": "^1.6.0",

--- a/src/plugins/deref-json-schemas/deref-json-schema.js
+++ b/src/plugins/deref-json-schemas/deref-json-schema.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { Resolver } = require("@stoplight/json-ref-resolver");
 const { resolveHttp } = require("@stoplight/json-ref-readers");
 const { merge, mergeWithCustomize } = require("webpack-merge");
@@ -13,7 +14,7 @@ function resolveFile(path) {
     path = `${schemasPath}/${path}`;
   }
 
-  return JSON.parse(fs.readFileSync(path));
+  return JSON.parse(fs.readFileSync(path, "utf-8"));
 }
 
 const resolver = new Resolver({
@@ -42,7 +43,7 @@ async function derefJsonSchema(schema) {
 }
 
 async function derefSchemaPath(schemaPath) {
-  const schema = JSON.parse(fs.readFileSync(schemaPath));
+  const schema = JSON.parse(fs.readFileSync(schemaPath, "utf-8"));
   return await derefJsonSchema(schema);
 }
 

--- a/src/plugins/deref-json-schemas/index.js
+++ b/src/plugins/deref-json-schemas/index.js
@@ -1,7 +1,6 @@
+// @ts-check
 const { schemasPath, derefSchemaPath } = require("./deref-json-schema");
 const fs = require("fs");
-
-const resolvedSchemas = {};
 
 function schemas() {
   return fs
@@ -10,7 +9,8 @@ function schemas() {
     .map((file) => `${schemasPath}/${file}`);
 }
 
-module.exports = async function derefJsonSchemas(context, options) {
+/** @returns {import('@docusaurus/types').Plugin}  */
+module.exports = function derefJsonSchemas(context, options) {
   return {
     name: "deref-json-schemas",
     async loadContent() {},
@@ -23,11 +23,12 @@ module.exports = async function derefJsonSchemas(context, options) {
         const schema = await derefSchemaPath(schemaPath);
         fs.writeFileSync(
           `${props.outDir}/${schemaPath}`,
-          JSON.stringify(schema)
+          JSON.stringify(schema),
         );
         console.log(`Wrote ${schemaPath}.`);
       }
     },
+    /** @returns {any} devServer is missing from the webpack config definition? */
     configureWebpack() {
       return {
         devServer: {
@@ -45,7 +46,7 @@ module.exports = async function derefJsonSchemas(context, options) {
                 } else {
                   resp.sendStatus(404);
                 }
-              }
+              },
             );
           },
         },

--- a/src/plugins/deref-json-schemas/index.js
+++ b/src/plugins/deref-json-schemas/index.js
@@ -1,6 +1,8 @@
 // @ts-check
-const { schemasPath, derefSchemaPath } = require("./deref-json-schema");
+const { derefSchemaPath } = require("./deref-json-schema");
 const fs = require("fs");
+
+const schemasPath = "schemas";
 
 function schemas() {
   return fs

--- a/yarn.lock
+++ b/yarn.lock
@@ -1923,6 +1923,11 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@jsdevtools/ono@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
+  integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
+
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
@@ -2039,14 +2044,6 @@
     p-map "^4.0.0"
     webpack-sources "^3.2.2"
 
-"@stoplight/json-ref-readers@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-ref-readers/-/json-ref-readers-1.2.2.tgz#e5992bae597f228f988f362a4c0304c03a92008b"
-  integrity sha512-nty0tHUq2f1IKuFYsLM4CXLZGHdMn+X/IwEUIpeSOXt0QjMUbL0Em57iJUDzz+2MkWG83smIigNZ3fauGjqgdQ==
-  dependencies:
-    node-fetch "^2.6.0"
-    tslib "^1.14.1"
-
 "@stoplight/json-ref-resolver@^3.1.5":
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/@stoplight/json-ref-resolver/-/json-ref-resolver-3.1.5.tgz#e4454a69027559ef3f7272941e99310a19dc8fdf"
@@ -2063,6 +2060,19 @@
     tslib "^2.3.1"
     urijs "^1.19.11"
 
+"@stoplight/json-schema-ref-parser@^9.2.5":
+  version "9.2.5"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-ref-parser/-/json-schema-ref-parser-9.2.5.tgz#2039445d06123758d17cf926f3ad6014d8e35d52"
+  integrity sha512-7UI3pX5oyGzAdGPah001CyPnIsJZJW+38sGjvx862zXQFidBe0sxFO5MUety61Zr/RaygCQ2RU/KfD7hSfOLxg==
+  dependencies:
+    "@jsdevtools/ono" "^7.1.3"
+    "@stoplight/path" "^1.3.2"
+    "@stoplight/yaml" "^4.0.2"
+    call-me-maybe "^1.0.1"
+    fastestsmallesttextencoderdecoder "^1.0.22"
+    isomorphic-fetch "^3.0.0"
+    node-abort-controller "^3.0.1"
+
 "@stoplight/json@^3.17.0":
   version "3.20.2"
   resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.20.2.tgz#466ba5c6381cfd141f1726439442fbd579804c8e"
@@ -2075,7 +2085,7 @@
     lodash "^4.17.21"
     safe-stable-stringify "^1.1"
 
-"@stoplight/ordered-object-literal@^1.0.3":
+"@stoplight/ordered-object-literal@^1.0.1", "@stoplight/ordered-object-literal@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@stoplight/ordered-object-literal/-/ordered-object-literal-1.0.4.tgz#c8bb2698ab229f31e31a16dd1852c867c1f2f2ed"
   integrity sha512-OF8uib1jjDs5/cCU+iOVy+GJjU3X7vk/qJIkIJFqwmlJKrrtijFmqwbu8XToXrwTYLQTP+Hebws5gtZEmk9jag==
@@ -2085,13 +2095,28 @@
   resolved "https://registry.yarnpkg.com/@stoplight/path/-/path-1.3.2.tgz#96e591496b72fde0f0cdae01a61d64f065bd9ede"
   integrity sha512-lyIc6JUlUA8Ve5ELywPC8I2Sdnh1zc1zmbYgVarhXIp9YeAB0ReeqmGEOWNtlHkbP2DAA1AL65Wfn2ncjK/jtQ==
 
-"@stoplight/types@^12.3.0 || ^13.0.0", "@stoplight/types@^13.6.0":
+"@stoplight/types@^12.3.0 || ^13.0.0", "@stoplight/types@^13.0.0", "@stoplight/types@^13.6.0":
   version "13.15.0"
   resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-13.15.0.tgz#d2db6820d92e5085193d03c3057d15c40a70e34f"
   integrity sha512-pBLjVRrWGVd+KzTbL3qrmufSKIEp0UfziDBdt/nrTHPKrlrtVwaHdrrQMcpM23yJDU1Wcg4cHvhIuGtKCT5OmA==
   dependencies:
     "@types/json-schema" "^7.0.4"
     utility-types "^3.10.0"
+
+"@stoplight/yaml-ast-parser@0.0.48":
+  version "0.0.48"
+  resolved "https://registry.yarnpkg.com/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.48.tgz#442b21f419427acaa8a3106ebc5d73351c407002"
+  integrity sha512-sV+51I7WYnLJnKPn2EMWgS4EUfoP4iWEbrWwbXsj0MZCB/xOK8j6+C9fntIdOM50kpx45ZLC3s6kwKivWuqvyg==
+
+"@stoplight/yaml@^4.0.2":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@stoplight/yaml/-/yaml-4.2.3.tgz#d177664fecd6b2fd0d4f264f1078550c30cfd8d1"
+  integrity sha512-Mx01wjRAR9C7yLMUyYFTfbUf5DimEpHMkRDQ1PKLe9dfNILbgdxyrncsOXM3vCpsQ1Hfj4bPiGl+u4u6e9Akqw==
+  dependencies:
+    "@stoplight/ordered-object-literal" "^1.0.1"
+    "@stoplight/types" "^13.0.0"
+    "@stoplight/yaml-ast-parser" "0.0.48"
+    tslib "^2.2.0"
 
 "@svgr/babel-plugin-add-jsx-attribute@^6.5.1":
   version "6.5.1"
@@ -3222,6 +3247,11 @@ call-bind@^1.0.0, call-bind@^1.0.2:
   dependencies:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
+
+call-me-maybe@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.2.tgz#03f964f19522ba643b1b0693acb9152fe2074baa"
+  integrity sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -4392,6 +4422,11 @@ fast-url-parser@1.1.3:
   dependencies:
     punycode "^1.3.2"
 
+fastestsmallesttextencoderdecoder@^1.0.22:
+  version "1.0.22"
+  resolved "https://registry.yarnpkg.com/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz#59b47e7b965f45258629cc6c127bf783281c5e93"
+  integrity sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==
+
 fastq@^1.6.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.15.0.tgz#d04d07c6a2a68fe4599fea8d2e103a937fae6b3a"
@@ -5359,6 +5394,14 @@ isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
+
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz#189e7909d0a39fa5a3dfad5b03f71947770191d3"
@@ -6262,6 +6305,11 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
+node-abort-controller@^3.0.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.1.1.tgz#a94377e964a9a37ac3976d848cb5c765833b8548"
+  integrity sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==
+
 node-emoji@^1.10.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.11.0.tgz#69a0150e6946e2f115e9d7ea4df7971e2628301c"
@@ -6276,7 +6324,7 @@ node-fetch@2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@^2.6.0:
+node-fetch@^2.6.1:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
   integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
@@ -8234,15 +8282,15 @@ ts-node@^10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-tslib@^1.14.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
 tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
+tslib@^2.2.0:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.3.tgz#24944ba2d990940e6e982c4bea147aba80209913"
+  integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==
 
 type-detect@4.0.8:
   version "4.0.8"
@@ -8741,6 +8789,11 @@ websocket-extensions@>=0.1.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
+
+whatwg-fetch@^3.4.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-url@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
(blocked, not ready for review)

Asana Task: [🐞 In schemas/ fix dereferencing](https://app.asana.com/0/1200273269966439/1204796800599703/f)
As discussed in #2

There's a bug in how we resolve and dereference refs.

This switches to a new library, https://github.com/stoplightio/json-schema-ref-parser , which has resolving and dereferencing that work with sensible defaults, instead of having to define it ourselves.

Unfortunately, that library has a related bug, in that it also doesn't recurse to resolve nested refs if a parent extends a ref.

I filed a bug report https://github.com/stoplightio/json-schema-ref-parser/issues/44 and also a partial fix https://github.com/stoplightio/json-schema-ref-parser/pull/45 , but I didn't manage to fix it all the way.

This PR and bugfix is blocked until that library's maintainers finishes and merges that PR and releases a new version. Alternatively, we could write our own custom resolving and dereferencing, but that seems error prone.

I'm opening this draft PR to document where I am in the bugfix process and to make it easier to resume once the library is updated.