### PR TITLE
feat (glides): add revenue field to trips_updated

### DIFF
--- a/docs/events/glides/com.mbta.ctd.glides.trips_updated.v1.mdx
+++ b/docs/events/glides/com.mbta.ctd.glides.trips_updated.v1.mdx
@@ -106,7 +106,7 @@ New restrictions on existing fields:
 - `endLocation` ([Location](.#location), conditionally required): where the trip will end. Required if `endTime` is specified.
 - At least one of `startLocation` and `endLocation` is required.
 - At least one of `startTime`, `endTime`, and `previousTripKey` is required.
-- `revenue` (boolean, optional): If this field is missing when adding a trip, the default is that the trip is in revenue service.
+- `revenue` (`"revenue"` | `"nonrevenue"`, optional): If this field is missing when adding a trip, the default is that the trip is in revenue service.
 - `dropped` SHOULD NOT be set.
 - All data SHOULD NOT be `"none"` or `"unset"`. (Instead, the fields would not be included).
 
@@ -138,7 +138,7 @@ Example:
 - `endLocation` ([Location](.#location)): where the trip is scheduled to end.
 - `startTime` ([Time](#time)): when the trip is scheduled to depart `startLocation`.
 - `endTime` ([Time](#time)): when the trip is scheduled to arrive at `endLocation`.
-- `revenue` (boolean, optional): whether the trip is scheduled to be in revenue service. If this field is missing, consumers SHOULD assume the trip is scheduled to be in revenue service.
+- `revenue` (`"revenue"` | `"nonrevenue"`, optional): Whether the trip is scheduled to be in revenue service. If this field is missing, consumers SHOULD assume the trip is scheduled to be in revenue service.
 
 Example:
 
@@ -166,7 +166,7 @@ Fields in the object:
 - `startTime` ([Time](#time) | "unset", optional): if present, the new time that the train is expected to depart `startLocation` (or the existing `startLocation` of the trip).
 - `endTime` ([Time](#time) | "unset", optional): if present, the new time that the train is expected to arrive at `endLocation` (or the existing `endLocation` of the trip).
 - `cars` (array of [Car](#car), optional): array of length 1 or 2, containing the car numbers and operators for each car in the train assigned to the trip. If absent, there are no changes to any cars. If present, the length of the array is the length of the train. In a two car train, the front car is listed first.
-- `revenue` (boolean, optional): Whether the trip is in revenue service.
+- `revenue` (`"revenue"` | `"nonrevenue"`, optional): Whether the trip is in revenue service.
 - `dropped` ([DroppedReason](#droppedreason) | false, optional): If present the trip was dropped for the provided reason. If set to `false`, the trip is not dropped (and restored if previously dropped).
 - `scheduled` ([Scheduled](#scheduled) | null): For trips in Glides' schedule, this represents the scheduled data for the trip. It will always be present and won't change between subsequent updates to the same trip. For added trips, this will always be `null`.
 

--- a/docs/events/glides/com.mbta.ctd.glides.trips_updated.v1.mdx
+++ b/docs/events/glides/com.mbta.ctd.glides.trips_updated.v1.mdx
@@ -106,6 +106,7 @@ New restrictions on existing fields:
 - `endLocation` ([Location](.#location), conditionally required): where the trip will end. Required if `endTime` is specified.
 - At least one of `startLocation` and `endLocation` is required.
 - At least one of `startTime`, `endTime`, and `previousTripKey` is required.
+- `revenue` (boolean, optional): If this field is missing when adding a trip, the default is that the trip is in revenue service.
 - `dropped` SHOULD NOT be set.
 - All data SHOULD NOT be `"none"` or `"unset"`. (Instead, the fields would not be included).
 
@@ -137,6 +138,7 @@ Example:
 - `endLocation` ([Location](.#location)): where the trip is scheduled to end.
 - `startTime` ([Time](#time)): when the trip is scheduled to depart `startLocation`.
 - `endTime` ([Time](#time)): when the trip is scheduled to arrive at `endLocation`.
+- `revenue` (boolean, optional): whether the trip is scheduled to be in revenue service. If this field is missing, consumers SHOULD assume the trip is scheduled to be in revenue service.
 
 Example:
 
@@ -164,6 +166,7 @@ Fields in the object:
 - `startTime` ([Time](#time) | "unset", optional): if present, the new time that the train is expected to depart `startLocation` (or the existing `startLocation` of the trip).
 - `endTime` ([Time](#time) | "unset", optional): if present, the new time that the train is expected to arrive at `endLocation` (or the existing `endLocation` of the trip).
 - `cars` (array of [Car](#car), optional): array of length 1 or 2, containing the car numbers and operators for each car in the train assigned to the trip. If absent, there are no changes to any cars. If present, the length of the array is the length of the train. In a two car train, the front car is listed first.
+- `revenue` (boolean, optional): Whether the trip is in revenue service.
 - `dropped` ([DroppedReason](#droppedreason) | false, optional): If present the trip was dropped for the provided reason. If set to `false`, the trip is not dropped (and restored if previously dropped).
 - `scheduled` ([Scheduled](#scheduled) | null): For trips in Glides' schedule, this represents the scheduled data for the trip. It will always be present and won't change between subsequent updates to the same trip. For added trips, this will always be `null`.
 

--- a/schemas/com.mbta.ctd.glides.trips_updated.v1.json
+++ b/schemas/com.mbta.ctd.glides.trips_updated.v1.json
@@ -125,7 +125,7 @@
           "properties": {
             "revenue": {
               "$comment": "if revenue is missing when adding a trip, assume it's in revenue service. if revenue is missing when updating a trip, that means no change, so there is no default",
-              "default": true
+              "default": "revenue"
             }
           }
         }
@@ -152,7 +152,10 @@
             "endLocation": { "$ref": "glides-events.json#/$defs/location" },
             "startTime": { "$ref": "#/$defs/time" },
             "endTime": { "$ref": "#/$defs/time" },
-            "revenue": { "type": "boolean", "default": true }
+            "revenue": {
+              "oneOf": [{ "const": "revenue" }, { "const": "nonrevenue" }],
+              "default": "revenue"
+            }
           },
           "required": ["startLocation", "endLocation", "startTime", "endTime"]
         }
@@ -191,7 +194,7 @@
           "items": { "$ref": "#/$defs/car" }
         },
         "revenue": {
-          "type": "boolean"
+          "oneOf": [{ "const": "revenue" }, { "const": "nonrevenue" }]
         },
         "dropped": {
           "oneOf": [{ "$ref": "#/$defs/dropped_reason" }, { "const": false }]

--- a/schemas/com.mbta.ctd.glides.trips_updated.v1.json
+++ b/schemas/com.mbta.ctd.glides.trips_updated.v1.json
@@ -120,6 +120,14 @@
               "required": ["previousTripKey"]
             }
           ]
+        },
+        {
+          "properties": {
+            "revenue": {
+              "$comment": "if revenue is missing when adding a trip, assume it's in revenue service. if revenue is missing when updating a trip, that means no change, so there is no default",
+              "default": true
+            }
+          }
         }
       ]
     },
@@ -143,7 +151,8 @@
             "startLocation": { "$ref": "glides-events.json#/$defs/location" },
             "endLocation": { "$ref": "glides-events.json#/$defs/location" },
             "startTime": { "$ref": "#/$defs/time" },
-            "endTime": { "$ref": "#/$defs/time" }
+            "endTime": { "$ref": "#/$defs/time" },
+            "revenue": { "type": "boolean", "default": true }
           },
           "required": ["startLocation", "endLocation", "startTime", "endTime"]
         }
@@ -180,6 +189,9 @@
           "minItems": 1,
           "maxItems": 2,
           "items": { "$ref": "#/$defs/car" }
+        },
+        "revenue": {
+          "type": "boolean"
         },
         "dropped": {
           "oneOf": [{ "$ref": "#/$defs/dropped_reason" }, { "const": false }]


### PR DESCRIPTION
Asana Task: [Publish nonrevenue trips to RTR](https://app.asana.com/0/616151179860796/1206310370383903/f)

Currently, Glides only publishes events for revenue trips, and all trips in the event stream are assumed to be revenue trips.

This adds a `revenue` field to the schema so we can publish nonrevenue trips. It adds the field to the `TripKey` so that it's possible to tell whether the scheduled trip is a pull or a revenue trip, and it adds it to `TripAdded` and `TripUpdated` so that Glides can add nonrevenue trips and change whether a trip is in service.

The default if the fields don't exist (as is today) is that the trip is assumed to be in service, so there are no immediate changes needed for Glides or RTR.

We will check with the transit data team before publishing any nonrevenue trips.

Is it okay with the transit data team if Glides begins publishing `revenue: true` for revenue trips without notice? This should be backwards compatible if RTR doesn't do anything with the field yet.