### PR TITLE
feat (glides): small changes to TODS location ids

### DIFF
--- a/docs/events/glides/index.mdx
+++ b/docs/events/glides/index.mdx
@@ -69,10 +69,8 @@ Fields:
 
 One of:
 
-- `{"gtfsId": "<GTFS stop ID>"}`, where the GTFS `location_type` is `1` (station).
-- `{"todsId": "<TODS stop ID"}`: id corresponding to `ops_location_id` in the upcoming TODS data. The data is still undergoing development and the specific ids are not yet finalized.
-
-Glides does not collect or publish any location data with GTFS `location_type` `0` (platform).
+- `{"gtfsId": "<GTFS stop ID>"}`, where the GTFS `location_type` is `1` (station). Glides doesn't differentiate between children of GTFS stops, so won't publish any GTFS child stop IDs.
+- `{"todsId": "<TODS stop ID"}`: ID corresponding to `ops_location_id` in the upcoming TODS data. These stops' `location_type` may be `0` (stop) or `1` (station).
 
 ### Metadata
 

--- a/docs/events/glides/index.mdx
+++ b/docs/events/glides/index.mdx
@@ -70,7 +70,7 @@ Fields:
 One of:
 
 - `{"gtfsId": "<GTFS stop ID>"}`, where the GTFS `location_type` is `1` (station).
-- `{"odsId": "<ODS stop ID"}`: id corresponding to `ops_location_id` in the upcoming ODS data. The data is still undergoing development and the specific ids are not yet finalized.
+- `{"todsId": "<TODS stop ID"}`: id corresponding to `ops_location_id` in the upcoming TODS data. The data is still undergoing development and the specific ids are not yet finalized.
 
 Glides does not collect or publish any location data with GTFS `location_type` `0` (platform).
 

--- a/examples/glides-events/editors_changed.v1.take_over.json
+++ b/examples/glides-events/editors_changed.v1.take_over.json
@@ -12,12 +12,12 @@
       },
       "inputTimestamp": "2023-01-20T09:29:59-05:00",
       "inputType": "take-over-editing",
-      "location": { "odsId": "lakst" }
+      "location": { "todsId": "lakst" }
     },
     "changes": [
       {
         "type": "stop",
-        "location": { "odsId": "lakst" },
+        "location": { "todsId": "lakst" },
         "editor": {
           "emailAddress": "binspector@example.com",
           "badgeNumber": "456"
@@ -25,7 +25,7 @@
       },
       {
         "type": "start",
-        "location": { "odsId": "lakst" },
+        "location": { "todsId": "lakst" },
         "editor": {
           "emailAddress": "ainspector@example.com",
           "badgeNumber": "123"

--- a/examples/glides-events/operator_signed_in.v1.json
+++ b/examples/glides-events/operator_signed_in.v1.json
@@ -12,7 +12,7 @@
       },
       "inputTimestamp": "2023-01-20T09:29:59-05:00",
       "inputType": "sign-in",
-      "location": { "odsId": "lakst" }
+      "location": { "todsId": "lakst" }
     },
     "operator": { "badgeNumber": "789" },
     "signedInAt": "2023-01-20T09:45:00-05:00",

--- a/schemas/glides-events.json
+++ b/schemas/glides-events.json
@@ -85,9 +85,9 @@
         },
         {
           "properties": {
-            "odsId": { "type": "string", "minLength": 1 }
+            "todsId": { "type": "string", "minLength": 1 }
           },
-          "required": ["odsId"]
+          "required": ["todsId"]
         }
       ]
     },


### PR DESCRIPTION
Asana Task: [Publish nonrevenue trips to RTR](https://app.asana.com/0/616151179860796/1206310370383903/f)

Glides may start publishing data about nonrevenue trips to kinesis soon (not before Transit Data is ready). Those trips will contain new TODS stop ids.

A couple small changes to prepare:

1. ODS was renamed to TODS (_Transit_ Operational Data Standard). We might as well fix the name now while it's easy, lest we get locked into an out of date name forever.

2. The new location ids are likely to be a mix of location_type 0 and 1. (Inner Belt will be a parent of two children `ibeltm` and `ibeltu`. Other yards will be location_type 0 unless we have a reason to make them parents.) The schema used to guarantee that Glides wouldn't publish child stops, but now we say we might publish TODS child stops (but still not GTFS child stops).

<details>
<summary>These changes are technically backwards incompatible, but Glides hasn't published nonrevenue location ids yet and AFAIK nobody's looking at them, so I don't expect this to break anything.</summary>

Some pedantic exceptions:

Glides has tried not to publish any nonrevenue locations, but we technically could have in two situations:

- We publish `operator_signed_in` and `editors_changed` events with a location of inner belt.
- In the unlikely event an inspector changes a revenue trip into a nonrevenue trip, and then moves it to a yard, we could accidentally publish data about it.

In either case, we would have published `{"gtfsId": "an internal id that's not in GTFS"}`. We've never published `{"odsId": "anything"}` before.
</details>

This and #5 can go in either order.