### PR TITLE
feat(glides): operator_signed_in's signature gets a version property

### DIFF
--- a/docs/events/glides/com.mbta.ctd.glides.operator_signed_in.v1.mdx
+++ b/docs/events/glides/com.mbta.ctd.glides.operator_signed_in.v1.mdx
@@ -35,8 +35,8 @@ How the operator signed that they were fit for duty.
 
 Fields:
 
-- `type` (string): How the the operator made their signature.
-- `version` (integer): The version of the sign-in text the operator agreed to.
+- `type` (string, optional): How the the operator made their signature.
+- `version` (integer, optional): The version of the sign-in text the operator agreed to.
 
 Current values for `type` are
 

--- a/docs/events/glides/com.mbta.ctd.glides.operator_signed_in.v1.mdx
+++ b/docs/events/glides/com.mbta.ctd.glides.operator_signed_in.v1.mdx
@@ -36,6 +36,7 @@ How the operator signed that they were fit for duty.
 Fields:
 
 - `type` (string): How the the operator made their signature.
+- `version` (integer): The version of the sign-in text the operator agreed to.
 
 Current values for `type` are
 

--- a/examples/glides-events/operator_signed_in.v1.json
+++ b/examples/glides-events/operator_signed_in.v1.json
@@ -1,6 +1,6 @@
 {
   "type": "com.mbta.ctd.glides.operator_signed_in.v1",
-  "specversion": "1.1",
+  "specversion": "1.0",
   "source": "glides.mbta.com",
   "id": "19fdb184-7dd6-4664-8472-04bd6177ec44",
   "time": "2023-01-20T09:30:00-05:00",

--- a/examples/glides-events/operator_signed_in.v1.json
+++ b/examples/glides-events/operator_signed_in.v1.json
@@ -1,6 +1,6 @@
 {
   "type": "com.mbta.ctd.glides.operator_signed_in.v1",
-  "specversion": "1.0",
+  "specversion": "1.1",
   "source": "glides.mbta.com",
   "id": "19fdb184-7dd6-4664-8472-04bd6177ec44",
   "time": "2023-01-20T09:30:00-05:00",
@@ -16,6 +16,6 @@
     },
     "operator": { "badgeNumber": "789" },
     "signedInAt": "2023-01-20T09:45:00-05:00",
-    "signature": { "type": "tap" }
+    "signature": { "type": "tap", "version": 1 }
   }
 }

--- a/schemas/com.mbta.ctd.glides.operator_signed_in.v1.json
+++ b/schemas/com.mbta.ctd.glides.operator_signed_in.v1.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "type": { "const": "com.mbta.ctd.glides.operator_signed_in.v1" },
-    "specversion": { "const": "1.0" },
+    "specversion": { "const": "1.1" },
     "source": { "$ref": "glides-events.json#/properties/source" },
     "id": { "$ref": "glides-events.json#/properties/id" },
     "time": { "$ref": "glides-events.json#/$defs/timestamp" },
@@ -28,6 +28,10 @@
         "type": {
           "type": "string",
           "examples": ["tap", "type"]
+        },
+        "version": {
+          "type": "integer",
+          "examples": [1]
         }
       }
     }

--- a/schemas/com.mbta.ctd.glides.operator_signed_in.v1.json
+++ b/schemas/com.mbta.ctd.glides.operator_signed_in.v1.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "type": { "const": "com.mbta.ctd.glides.operator_signed_in.v1" },
-    "specversion": { "const": "1.1" },
+    "specversion": { "const": "1.0" },
     "source": { "$ref": "glides-events.json#/properties/source" },
     "id": { "$ref": "glides-events.json#/properties/id" },
     "time": { "$ref": "glides-events.json#/$defs/timestamp" },

--- a/schemas/com.mbta.ctd.glides.operator_signed_in.v1.json
+++ b/schemas/com.mbta.ctd.glides.operator_signed_in.v1.json
@@ -17,7 +17,7 @@
         "signedInAt": { "$ref": "glides-events.json#/$defs/timestamp" },
         "signature": { "$ref": "#/$defs/signature" }
       },
-      "required": ["metadata"]
+      "required": ["metadata", "operator", "signedInAt", "signature"]
     }
   },
   "required": ["type", "specversion", "source", "id", "time", "data"],


### PR DESCRIPTION
Glides began tracking sign-in text version earlier this year, and we're planning on adding that to kinesis events.