### PR TITLE
docs(glides): trips_updated could publish schedules via no-op events

### DIFF
--- a/docs/events/glides/com.mbta.ctd.glides.trips_updated.v1.mdx
+++ b/docs/events/glides/com.mbta.ctd.glides.trips_updated.v1.mdx
@@ -7,6 +7,7 @@ import EventSchemaPath from "@site/src/components/EventSchemaPath.tsx";
 import Examples from "@site/src/components/Examples.tsx";
 import exampleDelay from "@site/examples/glides-events/trips_updated.v1.delay.json";
 import exampleDroppedAndHeadway from "@site/examples/glides-events/trips_updated.v1.dropped_and_headway.json";
+import examplePublishSchedule from "@site/examples/glides-events/trips_updated.v1.publish_schedule.json";
 import exampleSplit from "@site/examples/glides-events/trips_updated.v1.split.json";
 
 # trips_updated
@@ -270,6 +271,42 @@ _Notes:_
         </>
       ),
       json: exampleSplit,
+    },
+    {
+      label: "Publishing a Schedule",
+      description: (
+        <>
+          <h3>Publishing a Schedule</h3>
+          <p>
+            Glides may be using a different schedule than consumers, so
+            consumers only know about a scheduled trip when it's referenced in
+            this feed. If Glides wants consumers to have data about a scheduled
+            trip, the spec allows for Glides to send an event that references
+            the trip, even if it wasn't edited.
+          </p>
+          <p>
+            Note how this event does not update any trips, and the `metadata`
+            field does not say this was in response to inspector input.
+          </p>
+          <p>
+            A consumer who receives and handles this event would now be able to
+            look up data about this trip. This could be useful if a consumer
+            wants to make predictions for trips that inspectors haven't edited
+            yet, or if a
+            [vehicle_trip_assignment](com.mbta.ctd.glides.vehicle_trip_assignment.v1.mdx)
+            assigns a vehicle to a trip that hasn't been edited.
+          </p>
+          <p>
+            Glides could send an event like this at the beginning of the day
+            containing the whole day's schedule, or it could send events with
+            only a couple of trips at a time, as they're needed. This example
+            doesn't prescribe how or whether Glides will do this or even what
+            `inputType` would be used, it's just to show that this approach is
+            possible.
+          </p>
+        </>
+      ),
+      json: examplePublishSchedule,
     },
   ]}
 />

--- a/examples/glides-events/trips_updated.v1.publish_schedule.json
+++ b/examples/glides-events/trips_updated.v1.publish_schedule.json
@@ -1,0 +1,52 @@
+{
+  "type": "com.mbta.ctd.glides.trips_updated.v1",
+  "specversion": "1.0",
+  "source": "glides.mbta.com",
+  "id": "19fdb184-7dd6-4664-8472-04bd6177ec44",
+  "time": "2024-11-21T17:00:00-05:00",
+  "data": {
+    "metadata": {
+      "inputType": "publish-schedule"
+    },
+    "tripUpdates": [
+      {
+        "type": "updated",
+        "tripKey": {
+          "serviceDate": "2024-11-21",
+          "tripId": "64085858",
+          "startLocation": { "gtfsId": "place-matt" },
+          "endLocation": { "gtfsId": "place-ashmt" },
+          "startTime": "10:00:00",
+          "endTime": "10:10:00"
+        },
+        "scheduled": {
+          "scheduledCars": [
+            {
+              "run": "500",
+              "operator": { "badgeNumber": "1234" }
+            }
+          ]
+        }
+      },
+      {
+        "type": "updated",
+        "tripKey": {
+          "serviceDate": "2024-11-21",
+          "tripId": "64085858",
+          "startLocation": { "gtfsId": "place-ashmt" },
+          "endLocation": { "gtfsId": "place-matt" },
+          "startTime": "10:11:00",
+          "endTime": "10:21:00"
+        },
+        "scheduled": {
+          "scheduledCars": [
+            {
+              "run": "500",
+              "operator": { "badgeNumber": "1234" }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This is an idea for how Glides could publish its schedule to RTR: As a `trips_updated` that mentions a trip but does not edit it.

There's been some chatter about whether Glides should publish its schedule at the beginning of the day, like OCS does, and this is one way that it could do that.

There was also a minor issue in https://github.com/mbta/schemas/pull/9 : If a vehicle is assigned to a scheduled trip that has never been edited, but the trip isn't in GTFS, then it's possible that RTR wouldn't be able to find information about the trip. One workaround to that could be to publish one of these events before publishing the `vehicle_trip_assignment`.

This PR adds a new example that follows the existing spec with no changes. It's possible this could just work with no special handling from RTR. Though Glides would need some work to decide when to send these events, and if we make important decisions about when to send events like this, that should be documented in a real normative way, not just as a hypothetical example.

This PR is mostly a way to share the idea and spark discussion. It could be merged as is, but it's not important to merge it and it's also not important that we start publishing events like this any time soon.