### PR TITLE
docs: clarify glides timezones

### DIFF
--- a/docs/events/glides/com.mbta.ctd.glides.operator_signed_in.v1.mdx
+++ b/docs/events/glides/com.mbta.ctd.glides.operator_signed_in.v1.mdx
@@ -18,7 +18,7 @@ Fields in the event's `data`:
 
 - `metadata` ([Metadata](.#metadata)): how the operator was signed in in Glides, including the inspector who signed them in.
 - `operator` ([Operator](.#operator)): the operator who signed in
-- `signedInAt` (RFC3999 timestamp): the time at which they signed in (this is separate from the event timestamp)
+- `signedInAt` (RFC3339 timestamp): the time at which they signed in (this is separate from the event timestamp)
 - `signature` ([Signature](#signature)): how the operator signed in.
 
 ### Metadata

--- a/docs/events/glides/com.mbta.ctd.glides.trips_updated.v1.mdx
+++ b/docs/events/glides/com.mbta.ctd.glides.trips_updated.v1.mdx
@@ -80,7 +80,7 @@ If fields are missing from ScheduledCar, it is not known who is scheduled to ope
 
 ### Time
 
-Time in the `HH:MM:SS` format. The time is measured from "noon minus 12h" of the service day (effectively midnight except for days on which daylight savings time changes occur). For times occurring after midnight, enter the time as a value greater than 24:00:00 in `HH:MM:SS` local time for the day on which the trip schedule begins. Effectively, a [GTFS Time](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#field-types) but without support for `H:MM:SS` times.
+Time in the `HH:MM:SS` format. The time is in eastern time, measured from "noon minus 12h" of the service day (effectively midnight except for days on which daylight savings time changes occur). For times occurring after midnight, enter the time as a value greater than 24:00:00 in `HH:MM:SS` local time for the day on which the trip schedule begins. Effectively, a [GTFS Time](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#field-types) but without support for `H:MM:SS` times.
 
 > _Example: `04:30:00` for 4:30AM or `25:35:00` for 1:35AM on the next day._
 
@@ -128,7 +128,7 @@ Consumers MAY check `tripId` to help match trips in this feed to GTFS. If a cons
 
 #### Added Trip
 
-- `serviceDate` (RFC3999 date): the service date for the trip.
+- `serviceDate` (RFC3339 date): the service date for the trip.
 - `glidesId` (string): unique value representing this trip for the given `serviceDate`.
 
 Example:
@@ -139,7 +139,7 @@ Example:
 
 #### Scheduled Trip
 
-- `serviceDate` (RFC3999 date): the service date for the trip.
+- `serviceDate` (RFC3339 date): the service date for the trip.
 - `tripId` (string, optional): ID, unique within the service date. Intended to match GTFS trip IDs, but may not.
 - `startLocation` ([Location](.#location)): where the trip is scheduled to start.
 - `endLocation` ([Location](.#location)): where the trip is scheduled to end.

--- a/docs/events/glides/com.mbta.ctd.glides.vehicle_trip_assignment.v1.mdx
+++ b/docs/events/glides/com.mbta.ctd.glides.vehicle_trip_assignment.v1.mdx
@@ -36,7 +36,7 @@ Note there is no [Metadata](index.mdx#metadata) field like in other events, beca
 
 Fields:
 
-- `serviceDate` (RFC3999 date): the service date for the trip.
+- `serviceDate` (RFC3339 date): the service date for the trip.
 - `tripId` (string): ID, unique within the service date. Trip IDs for scheduled trips are intended to match GTFS trip IDs, but may not.
 - `scheduled` (`"scheduled"` | `"added"`): Whether this is a trip that Glides has in its schedule or that Glides added.
 

--- a/docs/events/glides/index.mdx
+++ b/docs/events/glides/index.mdx
@@ -126,6 +126,8 @@ It is represented as an object to provide future extensibility if needed.
 
 All timestamps MUST have a timezone offset, as required by RFC3339. The timestamp SHOULD be in UTC with an offset of "Z".
 
+> _Example: `"2025-01-01T17:00:00Z"` for noon eastern time._
+
 ## Details
 
 Events are in the [CloudEvents](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md) format, and published via AWS Kinesis. See [RFC 19 Event Driven Architecture](https://github.com/mbta/technology-docs/blob/main/rfcs/accepted/0019-event-driven-architecture.md) for more about CTD's approach to publishing events.

--- a/docs/events/glides/index.mdx
+++ b/docs/events/glides/index.mdx
@@ -94,7 +94,7 @@ All fields are optional and Glides MAY choose not to include any of them on any 
 Fields:
 
 - `author` ([GlidesUser](#glidesuser), optional): The logged-in user whose action triggered the event.
-- `inputTimestamp` (RFC3999 timestamp, optional): The timestamp that the user entered the data into Glides, as reported by their device. You probably want to use the event time instead. See [more explanation](#a-note-about-inputtimestamp) below.
+- `inputTimestamp` (RFC3339 timestamp, optional): The timestamp that the user entered the data into Glides, as reported by their device. You probably want to use the event time instead. See [more explanation](#a-note-about-inputtimestamp) below.
 - `inputType` (string, optional): the action that the user did in Glides. This field exists because the event data on its own may not specify how the data was entered, for example all trainsheet updates are normalized into a generic format in `tripUpdates`. Example values for this field are `"add-trip"` or `"manage-headways"`, but no guarantees are given about what strings will be used or which actions the field will be populated for.
 - `location` ([Location](#location), optional): the location the logged-in user is managing.
 
@@ -121,6 +121,10 @@ Fields:
 MAY refer to other non-operator Area 132 employees in some cases, for example if an inspector signs in as fit for duty in Glides (they aren't required to).
 
 It is represented as an object to provide future extensibility if needed.
+
+### RFC3339 Timestamp
+
+All timestamps MUST have a timezone offset, as required by RFC3339. The timestamp SHOULD be in UTC with an offset of "Z".
 
 ## Details
 


### PR DESCRIPTION
Asana Task: [🛠 Clarify Kinesis event spec with timezones](https://app.asana.com/0/1200882337457260/1209560338979101)

Docs update only, no changes to the spec.