### PR TITLE
fix(rtr): rename nextStopId => stopId

### DIFF
--- a/docs/events/rtr/com.mbta.rtr.lightrail-vehicle-updated.mdx
+++ b/docs/events/rtr/com.mbta.rtr.lightrail-vehicle-updated.mdx
@@ -24,7 +24,7 @@ Fields in the event's `data`:
 - `routeId` (string): Route that RTR thinks the vehicle is serving. See [GTFS's trips.txt](https://gtfs.org/documentation/schedule/reference/#tripstxt).
 - `consist` (array[string]): Array containing car numbers of the train in order
 - `orientation` (enum, values: ["AB", "BA"]): Whether the 'rear' or 'front' of each train is facing forward for each train in the consist. B means backward, A means forward
-- `stopId` (string): Identifier for the next stop that the vehicle is at / approaching. This will be a stop in GTFS parlance (`location_type = 0`), as opposed to a station (`location_type = 1`). See [GTFS's stops.txt documentation.](https://gtfs.org/documentation/schedule/reference/#stopstxt)
+- `stopId` (string): Identifier for the stop that the vehicle is at / approaching (the same stop provided for the vehicle in `VehiclePositions`) This will be a stop in GTFS parlance (`location_type = 0`), as opposed to a station (`location_type = 1`). See [GTFS's stops.txt documentation.](https://gtfs.org/documentation/schedule/reference/#stopstxt)
 - `stopStatus` (enum, values: ["STOPPED_AT", "INCOMING_AT", "IN_TRANSIT_TO"]): What the train is doing in relation to the next stop
 - `lat` (number): Most recent latitude of the vehicle
 - `lon` (number): Most recent longitude of the vehicle

--- a/docs/events/rtr/com.mbta.rtr.lightrail-vehicle-updated.mdx
+++ b/docs/events/rtr/com.mbta.rtr.lightrail-vehicle-updated.mdx
@@ -24,7 +24,7 @@ Fields in the event's `data`:
 - `routeId` (string): Route that RTR thinks the vehicle is serving. See [GTFS's trips.txt](https://gtfs.org/documentation/schedule/reference/#tripstxt).
 - `consist` (array[string]): Array containing car numbers of the train in order
 - `orientation` (enum, values: ["AB", "BA"]): Whether the 'rear' or 'front' of each train is facing forward for each train in the consist. B means backward, A means forward
-- `nextStopId` (string): Identifier for the next stop that the vehicle is at / approaching. This will be a stop in GTFS parlance (`location_type = 0`), as opposed to a station (`location_type = 1`). See [GTFS's stops.txt documentation.](https://gtfs.org/documentation/schedule/reference/#stopstxt)
+- `stopId` (string): Identifier for the next stop that the vehicle is at / approaching. This will be a stop in GTFS parlance (`location_type = 0`), as opposed to a station (`location_type = 1`). See [GTFS's stops.txt documentation.](https://gtfs.org/documentation/schedule/reference/#stopstxt)
 - `stopStatus` (enum, values: ["STOPPED_AT", "INCOMING_AT", "IN_TRANSIT_TO"]): What the train is doing in relation to the next stop
 - `lat` (number): Most recent latitude of the vehicle
 - `lon` (number): Most recent longitude of the vehicle

--- a/examples/rtr-events/LightRailVehicleUpdated.json
+++ b/examples/rtr-events/LightRailVehicleUpdated.json
@@ -6,7 +6,7 @@
       "routeId": "Green-D",
       "consist": ["3644", "3862"],
       "orientation": "AB",
-      "nextStopId": "70203",
+      "stopId": "70203",
       "stopStatus": "IN_TRANSIT_TO",
       "lat": 42.21469,
       "lon": -71.03305,

--- a/schemas/com.mbta.rtr.lightrail-vehicle-updated.json
+++ b/schemas/com.mbta.rtr.lightrail-vehicle-updated.json
@@ -37,7 +37,7 @@
         "routeId",
         "consist",
         "orientation",
-        "nextStopId",
+        "stopId",
         "stopStatus",
         "lat",
         "lon",
@@ -71,7 +71,7 @@
           "type": "string",
           "enum": ["AB", "BA"]
         },
-        "nextStopId": {
+        "stopId": {
           "type": "string",
           "examples": ["70160", "70161", "70238"]
         },


### PR DESCRIPTION
Problem:
We were giving the next stop ID to glides as part of the LRV kinesis stream, but Glides needs the "current" stop ID (e.g. the stop for which we are making the next prediction, and the stop that shows up in VehiclePositions)

Solution:
In the light rail updates feed, ovide the stop ID from the prediction we use to generate stopStatus instead of using next_stop_id from the vehicle's pattern.