### PR TITLE
feat(rtr): document that consist can be null in RTR vehicles feed

### DIFF
--- a/docs/events/rtr/com.mbta.rtr.lightrail-vehicle-updated.mdx
+++ b/docs/events/rtr/com.mbta.rtr.lightrail-vehicle-updated.mdx
@@ -22,7 +22,7 @@ Fields in the event's `data`:
 - `lastAvi` (string): The last AVI code that was emitted from the vehicle. If you are internal to the MBTA, see the [RTR documentation on AVI codes](https://github.com/mbta/rtr/blob/f734e361cb7361ec0cde461add8e1e1bfc938b74/docs/avi_codes.pdf)
 - `vehicleId` (string): Unique identifier of the vehicle from OCS
 - `routeId` (string): Route that RTR thinks the vehicle is serving. See [GTFS's trips.txt](https://gtfs.org/documentation/schedule/reference/#tripstxt).
-- `consist` (array[string]): Array containing car numbers of the train in order
+- `consist` (array[string] | null): Array containing car numbers of the train in order
 - `orientation` (enum, values: ["AB", "BA"]): Whether the 'rear' or 'front' of each train is facing forward for each train in the consist. B means backward, A means forward
 - `stopId` (string): Identifier for the stop that the vehicle is at / approaching (the same stop provided for the vehicle in `VehiclePositions`) This will be a stop in GTFS parlance (`location_type = 0`), as opposed to a station (`location_type = 1`). See [GTFS's stops.txt documentation.](https://gtfs.org/documentation/schedule/reference/#stopstxt)
 - `stopStatus` (enum, values: ["STOPPED_AT", "INCOMING_AT", "IN_TRANSIT_TO"]): What the train is doing in relation to the next stop

--- a/schemas/com.mbta.rtr.lightrail-vehicle-updated.json
+++ b/schemas/com.mbta.rtr.lightrail-vehicle-updated.json
@@ -62,10 +62,15 @@
           "enum": ["Green-B", "Green-C", "Green-D", "Green-D", "Mattapan"]
         },
         "consist": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            { "const": null }
+          ],
           "examples": [["3644", "3862"]]
         },
         "orientation": {


### PR DESCRIPTION
Per conversation between myself, @mathcolo, and @rudiejd, updating the spec to reflect the fact that a consist can be `null` (as opposed to an empty array) if we don't have that data for a vehicle for whatever reason.