### PR TITLE
feat(glides): add revenue field to trip assignment message

### DIFF
--- a/docs/events/glides/com.mbta.ctd.glides.vehicle_trip_assignment.v1.mdx
+++ b/docs/events/glides/com.mbta.ctd.glides.vehicle_trip_assignment.v1.mdx
@@ -25,6 +25,7 @@ Fields in the event's `data`:
 
 - `vehicleId` (string): The vehicle ID that Glides gets from RTR via GTFS-RT. E.g. `"G-10223"`
 - `tripKey` ([TripKey](#tripkey) | null):
+- `revenue` (`"revenue"` | `"nonrevenue"`, optional): Whether the trip is scheduled to be in revenue service. If this field is missing, consumers SHOULD assume the trip is scheduled to be in revenue service.
 
 If a `tripKey` is `null`, that means the vehicle is not assigned to a trip.
 

--- a/docs/events/glides/com.mbta.ctd.glides.vehicle_trip_assignment.v1.mdx
+++ b/docs/events/glides/com.mbta.ctd.glides.vehicle_trip_assignment.v1.mdx
@@ -25,7 +25,7 @@ Fields in the event's `data`:
 
 - `vehicleId` (string): The vehicle ID that Glides gets from RTR via GTFS-RT. E.g. `"G-10223"`
 - `tripKey` ([TripKey](#tripkey) | null):
-- `revenue` (`"revenue"` | `"nonrevenue"`, optional): Whether the trip is scheduled to be in revenue service. If this field is missing, consumers SHOULD assume the trip is scheduled to be in revenue service.
+- `revenue` (`"revenue"` | `"nonrevenue"`, optional): Whether the trip is scheduled to be in revenue service. This field will only be missing if Glides is unassigning the vehicle from a trip, e.g. if `VehicleTripAssignment.tripKey` is `null`.
 
 If a `tripKey` is `null`, that means the vehicle is not assigned to a trip.
 

--- a/examples/glides-events/vehicle_trip_assignment.v1.json
+++ b/examples/glides-events/vehicle_trip_assignment.v1.json
@@ -7,7 +7,8 @@
     "time": "2024-11-14T09:50:00-05:00",
     "data": {
       "vehicleId": "G-12345",
-      "tripKey": null
+      "tripKey": null,
+      "revenue": null
     }
   },
   {
@@ -22,7 +23,8 @@
         "serviceDate": "2024-11-14",
         "tripId": "11111111",
         "scheduled": "scheduled"
-      }
+      },
+      "revenue": "revenue"
     }
   },
   {
@@ -37,7 +39,8 @@
         "serviceDate": "2024-11-14",
         "tripId": "22222222",
         "scheduled": "scheduled"
-      }
+      },
+      "revenue": "nonrevenue"
     }
   },
   {
@@ -48,7 +51,8 @@
     "time": "2024-11-14T11:55:00-05:00",
     "data": {
       "vehicleId": "G-12345",
-      "tripKey": null
+      "tripKey": null,
+      "revenue": null
     }
   }
 ]

--- a/schemas/com.mbta.ctd.glides.vehicle_trip_assignment.v1.json
+++ b/schemas/com.mbta.ctd.glides.vehicle_trip_assignment.v1.json
@@ -21,8 +21,12 @@
           "oneOf": [{ "$ref": "#/$defs/trip_key" }, { "const": null }]
         },
         "revenue": {
-          "oneOf": [{ "const": "revenue" }, { "const": "nonrevenue" }]
-        },
+          "oneOf": [
+            { "const": "revenue" },
+            { "const": "nonrevenue" },
+            { "const": null }
+          ]
+        }
       },
       "required": ["vehicleId", "tripKey"]
     }

--- a/schemas/com.mbta.ctd.glides.vehicle_trip_assignment.v1.json
+++ b/schemas/com.mbta.ctd.glides.vehicle_trip_assignment.v1.json
@@ -19,7 +19,10 @@
         },
         "tripKey": {
           "oneOf": [{ "$ref": "#/$defs/trip_key" }, { "const": null }]
-        }
+        },
+        "revenue": {
+          "oneOf": [{ "const": "revenue" }, { "const": "nonrevenue" }]
+        },
       },
       "required": ["vehicleId", "tripKey"]
     }


### PR DESCRIPTION
Asana Ticket: [🔮🐛 Investigate and fix problematic revenue predictions](https://app.asana.com/1/15492006741476/project/584764604969369/task/1212917030453989?focus=true)

Adds a revenue field to the `VehicleTripAssignment` message from Glides. See https://github.com/mbta/glides/pull/3251 for a description of why this field was necessary.