### PR TITLE
feat(glides): add `uiVersion` to event metadata

### DIFF
--- a/docs/events/glides/com.mbta.ctd.glides.trips_updated.v1.mdx
+++ b/docs/events/glides/com.mbta.ctd.glides.trips_updated.v1.mdx
@@ -19,7 +19,7 @@ Published when Glides has new information about trips, for example operator assi
 
 Fields in the event's `data`:
 
-- `metadata` ([Metadata](.#metadata)): how the updates were entered in Glides, including the inspector who made the change and the location of the trainsheet.
+- `metadata` ([Metadata](.#metadata)): how the updates were entered in Glides, including the inspector who made the change, the version of Glides UI they were using, and the location of the trainsheet.
 - `tripUpdates` (array of ([TripUpdated](#tripupdated)|[TripAdded](#tripadded))): The list of one or more trips that have new information.
 
 ### Car

--- a/docs/events/glides/index.mdx
+++ b/docs/events/glides/index.mdx
@@ -97,6 +97,7 @@ Fields:
 - `inputTimestamp` (RFC3339 timestamp, optional): The timestamp that the user entered the data into Glides, as reported by their device. You probably want to use the event time instead. See [more explanation](#a-note-about-inputtimestamp) below.
 - `inputType` (string, optional): the action that the user did in Glides. This field exists because the event data on its own may not specify how the data was entered, for example all trainsheet updates are normalized into a generic format in `tripUpdates`. Example values for this field are `"add-trip"` or `"manage-headways"`, but no guarantees are given about what strings will be used or which actions the field will be populated for.
 - `location` ([Location](#location), optional): the location the logged-in user is managing.
+- `uiVersion` (string, optional): The version of the Glides UI that the editing inspector was using. A canonical version list will be maintained by the Glides application team.
 
 #### A note about `inputTimestamp`
 

--- a/docs/events/glides/index.mdx
+++ b/docs/events/glides/index.mdx
@@ -97,7 +97,7 @@ Fields:
 - `inputTimestamp` (RFC3339 timestamp, optional): The timestamp that the user entered the data into Glides, as reported by their device. You probably want to use the event time instead. See [more explanation](#a-note-about-inputtimestamp) below.
 - `inputType` (string, optional): the action that the user did in Glides. This field exists because the event data on its own may not specify how the data was entered, for example all trainsheet updates are normalized into a generic format in `tripUpdates`. Example values for this field are `"add-trip"` or `"manage-headways"`, but no guarantees are given about what strings will be used or which actions the field will be populated for.
 - `location` ([Location](#location), optional): the location the logged-in user is managing.
-- `uiVersion` (string, optional): The version of the Glides UI that the editing inspector was using. A canonical version list will be maintained by the Glides application team.
+- `uiVersion` (string, optional): The version of the Glides UI that the editing inspector used. The Glides application team updates this value to experiment with app features.
 
 #### A note about `inputTimestamp`
 

--- a/examples/glides-events/trips_updated.v1.delay.json
+++ b/examples/glides-events/trips_updated.v1.delay.json
@@ -6,7 +6,8 @@
   "time": "2023-01-23T01:25:00-05:00",
   "data": {
     "metadata": {
-      "inputType": "edit-trip"
+      "inputType": "edit-trip",
+      "uiVersion": "1"
     },
     "tripUpdates": [
       {

--- a/examples/glides-events/trips_updated.v1.dropped_and_headway.json
+++ b/examples/glides-events/trips_updated.v1.dropped_and_headway.json
@@ -7,7 +7,8 @@
     "time": "2023-01-20T09:30:00-05:00",
     "data": {
       "metadata": {
-        "inputType": "dropped-trip"
+        "inputType": "dropped-trip",
+        "uiVersion": "1"
       },
       "tripUpdates": [
         {

--- a/examples/glides-events/trips_updated.v1.split.json
+++ b/examples/glides-events/trips_updated.v1.split.json
@@ -7,7 +7,8 @@
     "time": "2023-01-20T09:30:00-05:00",
     "data": {
       "metadata": {
-        "inputType": "dropped-trip"
+        "inputType": "dropped-trip",
+        "uiVersion": "1"
       },
       "tripUpdates": [
         {

--- a/schemas/glides-events.json
+++ b/schemas/glides-events.json
@@ -99,7 +99,8 @@
         "author": { "$ref": "#/$defs/glides_user" },
         "inputTimestamp": { "$ref": "#/$defs/timestamp" },
         "inputType": { "type": "string", "minLength": 1 },
-        "location": { "$ref": "#/$defs/location" }
+        "location": { "$ref": "#/$defs/location" },
+        "uiVersion": { "type": "string", "minLength": 1 }
       }
     },
     "operator": {


### PR DESCRIPTION
Asana Ticket: [Add a new "UI version" field to the glides.trips_updated message sent to LAMP](https://app.asana.com/1/15492006741476/project/1200273269966439/task/1213727881505444)

See accompanying Glides PR https://github.com/mbta/glides/pull/3287 for the implementation of this proposal. (I will wait for feedback and approval on the schema change here before merging that.)

Adds a `uiVersion` field to Glides events metadata. This is expected to be a non-breaking change. Some more notes:
- The field is a string to allow for flexibility rather than locking into a particular versioning scheme. Glides team will be responsible for maintaining the canonical set of expected values.
- Like all event metadata fields, this one is optional. We expect to populate it on `trips_updated` going forward, but not on other events unless it becomes necessary.